### PR TITLE
nrf_rpc: Two-way handshake initialization

### DIFF
--- a/nrf_rpc/Kconfig
+++ b/nrf_rpc/Kconfig
@@ -40,13 +40,11 @@ config NRF_RPC_CMD_CTX_POOL_SIZE
 	  threads in both local and remote pool.
 
 config NRF_RPC_GROUP_INIT_WAIT_TIME
-	int "Group initialization timeout"
+	int "Group initialization timeout in milliseconds"
 	default 1000
-	range 10 5000
 	help
-	  The time period to wait for the remote cores to send group init responses with
-	  destination group ids.
-	  The time is given in miliseconds.
+	  The number of milliseconds to wait for the remote cores to send group
+	  init packets with destination group ids. Set to -1 to wait forever.
 
 config NRF_RPC_THREAD_POOL_SIZE
 	int "Number of threads in local thread pool"


### PR DESCRIPTION
Implement two-way handshake nRF RPC initialization: When an initialization packet with the unknown destination group ID is received, reply to that with an initialization packet with the right destination group ID.

This makes it possible to re-establish the link even if either peer has rebooted, or has booted with a delay.

Also, allow to configure infinite group init timeout.